### PR TITLE
Fix for avr-rust issue 129

### DIFF
--- a/include/llvm/CodeGen/TargetLowering.h
+++ b/include/llvm/CodeGen/TargetLowering.h
@@ -3363,7 +3363,7 @@ public:
   /// but for some platform that would break. So this method will default to
   /// matching the endianness but can be overridden.
   virtual bool
-  functionArgumentsSplitLittleEndian(const DataLayout &DL) const {
+  shouldSplitFunctionArgumentsAsLittleEndian(const DataLayout &DL) const {
     return DL.isLittleEndian();
   }
 

--- a/include/llvm/CodeGen/TargetLowering.h
+++ b/include/llvm/CodeGen/TargetLowering.h
@@ -3358,6 +3358,15 @@ public:
     return false;
   }
 
+  /// For some targets, an LLVM type must be broken down into multiple
+  /// smaller types. Usually the halves are ordered according to the endianness
+  /// but for some platform that would break. So this method will default to
+  /// matching the endianness but can be overridden.
+  virtual bool
+  functionArgumentsSplitLittleEndian(const DataLayout &DL) const {
+    return DL.isLittleEndian();
+  }
+
   /// Returns a 0 terminated array of registers that can be safely used as
   /// scratch registers.
   virtual const MCPhysReg *getScratchRegisters(CallingConv::ID CC) const {

--- a/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3398,7 +3398,7 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
       // being a legal type for the architecture and thus has to be split to
       // two arguments.
       SDValue Ret;
-      if(TLI.functionArgumentsSplitLittleEndian(DAG.getDataLayout())) {
+      if(TLI.shouldSplitFunctionArgumentsAsLittleEndian(DAG.getDataLayout())) {
         // Halves of WideVT are packed into registers in different order
         // depending on platform endianness. This is usually handled by
         // the C calling convention, but we can't defer to it in

--- a/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3398,7 +3398,7 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
       // being a legal type for the architecture and thus has to be split to
       // two arguments.
       SDValue Ret;
-      if(DAG.getDataLayout().isLittleEndian()) {
+      if(TLI.functionArgumentsSplitLittleEndian(DAG.getDataLayout())) {
         // Halves of WideVT are packed into registers in different order
         // depending on platform endianness. This is usually handled by
         // the C calling convention, but we can't defer to it in

--- a/lib/Target/AVR/AVRISelLowering.h
+++ b/lib/Target/AVR/AVRISelLowering.h
@@ -129,6 +129,11 @@ public:
   unsigned getRegisterByName(const char* RegName, EVT VT,
                              SelectionDAG &DAG) const override;
 
+  bool functionArgumentsSplitLittleEndian(const DataLayout &DL)
+    const override {
+      return false;
+  }
+
 private:
   SDValue getAVRCmp(SDValue LHS, SDValue RHS, ISD::CondCode CC, SDValue &AVRcc,
                     SelectionDAG &DAG, SDLoc dl) const;

--- a/lib/Target/AVR/AVRISelLowering.h
+++ b/lib/Target/AVR/AVRISelLowering.h
@@ -129,7 +129,7 @@ public:
   unsigned getRegisterByName(const char* RegName, EVT VT,
                              SelectionDAG &DAG) const override;
 
-  bool functionArgumentsSplitLittleEndian(const DataLayout &DL)
+  bool shouldSplitFunctionArgumentsAsLittleEndian(const DataLayout &DL)
     const override {
     return false;
   }

--- a/lib/Target/AVR/AVRISelLowering.h
+++ b/lib/Target/AVR/AVRISelLowering.h
@@ -131,7 +131,7 @@ public:
 
   bool functionArgumentsSplitLittleEndian(const DataLayout &DL)
     const override {
-      return false;
+    return false;
   }
 
 private:

--- a/test/CodeGen/AVR/umul.with.overflow.i16-bug.ll
+++ b/test/CodeGen/AVR/umul.with.overflow.i16-bug.ll
@@ -1,0 +1,52 @@
+; RUN: llc -O1 < %s -march=avr | FileCheck %s
+
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.9"
+
+%Vs6UInt16 = type <{ i16 }>
+%Sb = type <{ i1 }>
+
+define hidden void @_TF4main13setServoAngleFT5angleVs6UInt16_T_(i16) #0 {
+  ; CHECK-LABEL: entry
+entry:
+  %adjustedAngle = alloca %Vs6UInt16, align 2
+  %1 = bitcast %Vs6UInt16* %adjustedAngle to i8*
+  %adjustedAngle._value = getelementptr inbounds %Vs6UInt16, %Vs6UInt16* %adjustedAngle, i32 0, i32 0
+  store i16 %0, i16* %adjustedAngle._value, align 2
+
+;print(unsignedInt: adjustedAngle &* UInt16(11))
+; breaks here
+  %adjustedAngle._value2 = getelementptr inbounds %Vs6UInt16, %Vs6UInt16* %adjustedAngle, i32 0, i32 0
+  %2 = load i16, i16* %adjustedAngle._value2, align 2
+
+; CHECK: mov r22, r24
+; CHECK: mov r23, r25
+
+; CHECK-DAG: ldi r20, 0
+; CHECK-DAG: ldi r21, 0
+; CHECK-DAG: ldi r18, 11
+; CHECK-DAG: ldi r19, 0
+
+; CHECK: mov r24, r20
+; CHECK: mov r25, r21
+; CHECK: call  __mulsi3
+  %3 = call { i16, i1 } @llvm.umul.with.overflow.i16(i16 %2, i16 11)
+  %4 = extractvalue { i16, i1 } %3, 0
+  %5 = extractvalue { i16, i1 } %3, 1
+
+  ; above code looks fine, how is it lowered?
+  %6 = call i1 @_TIF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_A0_()
+  call void @_TF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_(i16 %4, i1 %6)
+
+; CHECK: ret
+  ret void
+}
+
+declare void @_TF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_(i16, i1) #0
+declare i1 @_TIF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_A0_() #0
+
+; Function Attrs: nounwind readnone speculatable
+declare { i16, i1 } @llvm.umul.with.overflow.i16(i16, i16) #2
+
+attributes #0 = { "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "target-cpu"="core2" "target-features"="+ssse3,+cx16,+fxsr,+mmx,+x87,+sse,+sse2,+sse3" }
+attributes #2 = { nounwind readnone speculatable }

--- a/test/CodeGen/AVR/umul.with.overflow.i16-bug.ll
+++ b/test/CodeGen/AVR/umul.with.overflow.i16-bug.ll
@@ -6,7 +6,7 @@ target triple = "x86_64-apple-macosx10.9"
 %Vs6UInt16 = type <{ i16 }>
 %Sb = type <{ i1 }>
 
-define hidden void @_TF4main13setServoAngleFT5angleVs6UInt16_T_(i16) #0 {
+define hidden void @setServoAngle(i16) #0 {
   ; CHECK-LABEL: entry
 entry:
   %adjustedAngle = alloca %Vs6UInt16, align 2
@@ -35,15 +35,15 @@ entry:
   %5 = extractvalue { i16, i1 } %3, 1
 
   ; above code looks fine, how is it lowered?
-  %6 = call i1 @_TIF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_A0_()
-  call void @_TF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_(i16 %4, i1 %6)
+  %6 = call i1 @printDefaultParam()
+  call void @print(i16 %4, i1 %6)
 
 ; CHECK: ret
   ret void
 }
 
-declare void @_TF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_(i16, i1) #0
-declare i1 @_TIF3AVR5printFT11unsignedIntVs6UInt1610addNewlineSb_T_A0_() #0
+declare void @print(i16, i1) #0
+declare i1 @printDefaultParam() #0
 
 ; Function Attrs: nounwind readnone speculatable
 declare { i16, i1 } @llvm.umul.with.overflow.i16(i16, i16) #2

--- a/test/CodeGen/AVR/umul.with.overflow.i16-bug.ll
+++ b/test/CodeGen/AVR/umul.with.overflow.i16-bug.ll
@@ -6,7 +6,7 @@ target triple = "x86_64-apple-macosx10.9"
 %Vs6UInt16 = type <{ i16 }>
 %Sb = type <{ i1 }>
 
-define hidden void @setServoAngle(i16) #0 {
+define hidden void @setServoAngle(i16) {
   ; CHECK-LABEL: entry
 entry:
   %adjustedAngle = alloca %Vs6UInt16, align 2
@@ -42,11 +42,8 @@ entry:
   ret void
 }
 
-declare void @print(i16, i1) #0
-declare i1 @printDefaultParam() #0
+declare void @print(i16, i1)
+declare i1 @printDefaultParam()
 
 ; Function Attrs: nounwind readnone speculatable
-declare { i16, i1 } @llvm.umul.with.overflow.i16(i16, i16) #2
-
-attributes #0 = { "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "target-cpu"="core2" "target-features"="+ssse3,+cx16,+fxsr,+mmx,+x87,+sse,+sse2,+sse3" }
-attributes #2 = { nounwind readnone speculatable }
+declare { i16, i1 } @llvm.umul.with.overflow.i16(i16, i16)


### PR DESCRIPTION
The bug is related to parameter ordering and endianness. (See avr-rust [rust-lang#129](https://github.com/rust-lang/llvm/pull/129).)

When a large type can't be legalised, it's broken into smaller types, those are passed as parameters in order based on the endianness of the platform, which is wrong in the case of AVR (at least) because of the way those parameters are then reversed into a semi-big-endian order for the AVR GCC ABI.

The problem is the legalising is in shared code, without any existing platform specific hooks that seemed appropriate, so I added an overridable function into the TypeLoweringInfo, overridden appropriately on the AVR platform to correct the issue on AVR.


Open to comments/suggestions, also...

i) this is not yet a complete fix because the return values are suffering a similar issue too
ii) the unit test is not complete, it doesn't yet test anything

