### PR TITLE
LowerCallResult regression bugfix

### DIFF
--- a/lib/Target/AVR/AVRISelLowering.cpp
+++ b/lib/Target/AVR/AVRISelLowering.cpp
@@ -1430,9 +1430,9 @@ AVRTargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
 
   SDValue Flag;
   SmallVector<SDValue, 4> RetOps(1, Chain);
-  unsigned e = RVLocs.size();
+  unsigned numberOfReturnParts = RVLocs.size();
   // Copy the result values into the output registers.
-  for (unsigned i = 0; i != e; ++i) {
+  for (unsigned i = 0; i != numberOfReturnParts; ++i) {
     CCValAssign &VA = RVLocs[i];
     assert(VA.isRegLoc() && "Can only return in registers!");
 

--- a/test/CodeGen/AVR/call-avr-rust-issue-130-regression.ll
+++ b/test/CodeGen/AVR/call-avr-rust-issue-130-regression.ll
@@ -1,0 +1,61 @@
+; RUN: llc -O1 < %s -march=avr | FileCheck %s
+
+; CHECK-LABEL: setServoAngle1
+define hidden i32 @setServoAngle1(i32) local_unnamed_addr {
+entry:
+  %1 = mul i32 %0, 19
+; CHECK: ldi r18, 19
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  __mulsi3
+; CHECK: ret
+  ret i32 %1
+}
+
+; CHECK-LABEL: setServoAngle2
+define hidden i16 @setServoAngle2(i32) local_unnamed_addr {
+entry:
+  %1 = mul i32 %0, 19
+; CHECK: ldi r18, 19
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  __mulsi3
+  %2 = trunc i32 %1 to i16
+; CHECK: mov r24, r22
+; CHECK: mov r25, r23
+; CHECK: ret
+  ret i16 %2
+}
+
+; CHECK-LABEL: setServoAngle3
+define hidden i32 @setServoAngle3(i32) local_unnamed_addr {
+entry:
+  %1 = call i32 @myExternalFunction1(i32 %0, i32 119)
+; CHECK: ldi r18, 119
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  myExternalFunction1
+; CHECK: ret
+  ret i32 %1
+}
+
+; CHECK-LABEL: setServoAngle4
+define hidden i16 @setServoAngle4(i32) local_unnamed_addr {
+entry:
+  %1 = call i32 @myExternalFunction1(i32 %0, i32 119)
+; CHECK: ldi r18, 119
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  myExternalFunction1
+  %2 = trunc i32 %1 to i16
+; CHECK: mov r24, r22
+; CHECK: mov r25, r23
+; CHECK: ret
+  ret i16 %2
+}
+
+declare i32 @myExternalFunction1(i32, i32)

--- a/test/CodeGen/AVR/directmem.ll
+++ b/test/CodeGen/AVR/directmem.ll
@@ -84,6 +84,11 @@ define i16 @global16_load() {
 define void @array16_store() {
 ; CHECK-LABEL: array16_store:
 
+; CHECK: ldi [[REG1:r[0-9]+]], 221
+; CHECK: ldi [[REG2:r[0-9]+]], 170
+; CHECK: sts int.array+5, [[REG2]]
+; CHECK: sts int.array+4, [[REG1]]
+
 ; CHECK: ldi [[REG1:r[0-9]+]], 204
 ; CHECK: ldi [[REG2:r[0-9]+]], 170
 ; CHECK: sts int.array+3, [[REG2]]
@@ -94,11 +99,6 @@ define void @array16_store() {
 ; CHECK: sts int.array+1, [[REG2]]
 ; CHECK: sts int.array, [[REG1]]
 
-
-; CHECK: ldi [[REG1:r[0-9]+]], 221
-; CHECK: ldi [[REG2:r[0-9]+]], 170
-; CHECK: sts int.array+5, [[REG2]]
-; CHECK: sts int.array+4, [[REG1]]
   store i16 43707, i16* getelementptr inbounds ([3 x i16], [3 x i16]* @int.array, i32 0, i64 0)
   store i16 43724, i16* getelementptr inbounds ([3 x i16], [3 x i16]* @int.array, i32 0, i64 1)
   store i16 43741, i16* getelementptr inbounds ([3 x i16], [3 x i16]* @int.array, i32 0, i64 2)
@@ -152,6 +152,14 @@ define i32 @global32_load() {
 
 define void @array32_store() {
 ; CHECK-LABEL: array32_store:
+; CHECK: ldi [[REG1:r[0-9]+]], 170
+; CHECK: ldi [[REG2:r[0-9]+]], 153
+; CHECK: sts long.array+11, [[REG2]]
+; CHECK: sts long.array+10, [[REG1]]
+; CHECK: ldi [[REG1:r[0-9]+]], 204
+; CHECK: ldi [[REG2:r[0-9]+]], 187
+; CHECK: sts long.array+9, [[REG2]]
+; CHECK: sts long.array+8, [[REG1]]
 ; CHECK: ldi [[REG1:r[0-9]+]], 102
 ; CHECK: ldi [[REG2:r[0-9]+]], 85
 ; CHECK: sts long.array+7, [[REG2]]
@@ -168,14 +176,6 @@ define void @array32_store() {
 ; CHECK: ldi [[REG2:r[0-9]+]], 13
 ; CHECK: sts long.array+1, [[REG2]]
 ; CHECK: sts long.array, [[REG1]]
-; CHECK: ldi [[REG1:r[0-9]+]], 170
-; CHECK: ldi [[REG2:r[0-9]+]], 153
-; CHECK: sts long.array+11, [[REG2]]
-; CHECK: sts long.array+10, [[REG1]]
-; CHECK: ldi [[REG1:r[0-9]+]], 204
-; CHECK: ldi [[REG2:r[0-9]+]], 187
-; CHECK: sts long.array+9, [[REG2]]
-; CHECK: sts long.array+8, [[REG1]]
   store i32 2887454020, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @long.array, i32 0, i64 0)
   store i32 1432778632, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @long.array, i32 0, i64 1)
   store i32 2578103244, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @long.array, i32 0, i64 2)


### PR DESCRIPTION
bugfix:
- The reversal function call had somehow got removed from LowerCallResult, meaning calls returning i32 (or greater) were effectively being word swapped

improvements:
- The function name ReverseArgumentsToBigEndian is (I think) a bit misleading, I suggest something like ReverseReturnValuePartsToEnsureLittleEndian
- Also added some explanatory comments to the function.
- Moved the check for whether this is a split return value or not outside the function as I think that's more clear.

tests:
- Added a test for the regression caused by the fixes to avr-rust#92 [https://github.com/avr-rust/rust/issues/92], which is also causing avr-rust#130 [https://github.com/avr-rust/rust/issues/130]
- corrected directmem.ll at the same time as that had become broken by e2baccfd07f2