### PR TITLE
Fix avr-rust issue #128 (crash when compiling, expected either Y or Z register)

### DIFF
--- a/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -583,8 +583,8 @@ bool AVRExpandPseudo::expand<AVR::LDWRdPtr>(Block &MBB, BlockIt MBBI) {
   unsigned TmpReg = 0; // 0 for no temporary register
   unsigned SrcReg = MI.getOperand(1).getReg();
   bool SrcIsKill = MI.getOperand(1).isKill();
-  OpLo = AVR::LDRdPtr;
-  OpHi = AVR::LDDRdPtrQ;
+  OpLo = AVR::LDRdPtrPi;
+  OpHi = AVR::LDRdPtr;
   TRI->splitReg(DstReg, DstLoReg, DstHiReg);
 
   // Use a temporary register if src and dst registers are the same.
@@ -597,7 +597,8 @@ bool AVRExpandPseudo::expand<AVR::LDWRdPtr>(Block &MBB, BlockIt MBBI) {
   // Load low byte.
   auto MIBLO = buildMI(MBB, MBBI, OpLo)
     .addReg(CurDstLoReg, RegState::Define)
-    .addReg(SrcReg, RegState::Define);
+    .addReg(SrcReg, RegState::Define)
+    .addReg(SrcReg);
 
   // Push low byte onto stack if necessary.
   if (TmpReg)
@@ -606,8 +607,7 @@ bool AVRExpandPseudo::expand<AVR::LDWRdPtr>(Block &MBB, BlockIt MBBI) {
   // Load high byte.
   auto MIBHI = buildMI(MBB, MBBI, OpHi)
     .addReg(CurDstHiReg, RegState::Define)
-    .addReg(SrcReg, getKillRegState(SrcIsKill))
-    .addImm(1);
+    .addReg(SrcReg, getKillRegState(SrcIsKill));
 
   if (TmpReg) {
     // Move the high byte into the final destination.

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -1155,7 +1155,7 @@ isReMaterializable = 1 in
   // ld Rd+1, P
   let Constraints = "@earlyclobber $reg" in
   def LDWRdPtr : Pseudo<(outs DREGS:$reg),
-                        (ins PTRREGS:$ptrreg),
+                        (ins PTRDISPREGS:$ptrreg),
                         "ldw\t$reg, $ptrreg",
                         [(set i16:$reg, (load i16:$ptrreg))]>,
                  Requires<[HasSRAM]>;

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -1153,11 +1153,11 @@ isReMaterializable = 1 in
   // Expands to:
   // ld Rd,   P+
   // ld Rd+1, P
-  let Constraints = "@earlyclobber $reg" in
-  def LDWRdPtr : Pseudo<(outs DREGS:$reg),
-                        (ins PTRDISPREGS:$ptrreg),
+  let Constraints = "$ptrreg = $base_wb,@earlyclobber $reg" in
+  def LDWRdPtr : Pseudo<(outs DREGS:$reg, PTRREGS:$base_wb),
+                        (ins PTRREGS:$ptrreg),
                         "ldw\t$reg, $ptrreg",
-                        [(set i16:$reg, (load i16:$ptrreg))]>,
+                        [(set i16:$reg, i16:$base_wb, (load i16:$ptrreg))]>,
                  Requires<[HasSRAM]>;
 }
 

--- a/test/CodeGen/AVR/call-avr-rust-issue-130-regression.ll
+++ b/test/CodeGen/AVR/call-avr-rust-issue-130-regression.ll
@@ -1,0 +1,61 @@
+; RUN: llc -O1 < %s -march=avr | FileCheck %s
+
+; CHECK-LABEL: setServoAngle1
+define hidden i32 @setServoAngle1(i32) local_unnamed_addr {
+entry:
+  %1 = mul i32 %0, 19
+; CHECK: ldi r18, 19
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  __mulsi3
+; CHECK: ret
+  ret i32 %1
+}
+
+; CHECK-LABEL: setServoAngle2
+define hidden i16 @setServoAngle2(i32) local_unnamed_addr {
+entry:
+  %1 = mul i32 %0, 19
+; CHECK: ldi r18, 19
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  __mulsi3
+  %2 = trunc i32 %1 to i16
+; CHECK: mov r24, r22
+; CHECK: mov r25, r23
+; CHECK: ret
+  ret i16 %2
+}
+
+; CHECK-LABEL: setServoAngle3
+define hidden i32 @setServoAngle3(i32) local_unnamed_addr {
+entry:
+  %1 = call i32 @myExternalFunction1(i32 %0, i32 119)
+; CHECK: ldi r18, 119
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  myExternalFunction1
+; CHECK: ret
+  ret i32 %1
+}
+
+; CHECK-LABEL: setServoAngle4
+define hidden i16 @setServoAngle4(i32) local_unnamed_addr {
+entry:
+  %1 = call i32 @myExternalFunction1(i32 %0, i32 119)
+; CHECK: ldi r18, 119
+; CHECK: ldi r19, 0
+; CHECK: ldi r20, 0
+; CHECK: ldi r21, 0
+; CHECK: call  myExternalFunction1
+  %2 = trunc i32 %1 to i16
+; CHECK: mov r24, r22
+; CHECK: mov r25, r23
+; CHECK: ret
+  ret i16 %2
+}
+
+declare i32 @myExternalFunction1(i32, i32)

--- a/test/CodeGen/AVR/directmem.ll
+++ b/test/CodeGen/AVR/directmem.ll
@@ -84,6 +84,11 @@ define i16 @global16_load() {
 define void @array16_store() {
 ; CHECK-LABEL: array16_store:
 
+; CHECK: ldi [[REG1:r[0-9]+]], 221
+; CHECK: ldi [[REG2:r[0-9]+]], 170
+; CHECK: sts int.array+5, [[REG2]]
+; CHECK: sts int.array+4, [[REG1]]
+
 ; CHECK: ldi [[REG1:r[0-9]+]], 204
 ; CHECK: ldi [[REG2:r[0-9]+]], 170
 ; CHECK: sts int.array+3, [[REG2]]
@@ -94,11 +99,6 @@ define void @array16_store() {
 ; CHECK: sts int.array+1, [[REG2]]
 ; CHECK: sts int.array, [[REG1]]
 
-
-; CHECK: ldi [[REG1:r[0-9]+]], 221
-; CHECK: ldi [[REG2:r[0-9]+]], 170
-; CHECK: sts int.array+5, [[REG2]]
-; CHECK: sts int.array+4, [[REG1]]
   store i16 43707, i16* getelementptr inbounds ([3 x i16], [3 x i16]* @int.array, i32 0, i64 0)
   store i16 43724, i16* getelementptr inbounds ([3 x i16], [3 x i16]* @int.array, i32 0, i64 1)
   store i16 43741, i16* getelementptr inbounds ([3 x i16], [3 x i16]* @int.array, i32 0, i64 2)
@@ -152,6 +152,14 @@ define i32 @global32_load() {
 
 define void @array32_store() {
 ; CHECK-LABEL: array32_store:
+; CHECK: ldi [[REG1:r[0-9]+]], 170
+; CHECK: ldi [[REG2:r[0-9]+]], 153
+; CHECK: sts long.array+11, [[REG2]]
+; CHECK: sts long.array+10, [[REG1]]
+; CHECK: ldi [[REG1:r[0-9]+]], 204
+; CHECK: ldi [[REG2:r[0-9]+]], 187
+; CHECK: sts long.array+9, [[REG2]]
+; CHECK: sts long.array+8, [[REG1]]
 ; CHECK: ldi [[REG1:r[0-9]+]], 102
 ; CHECK: ldi [[REG2:r[0-9]+]], 85
 ; CHECK: sts long.array+7, [[REG2]]
@@ -168,14 +176,6 @@ define void @array32_store() {
 ; CHECK: ldi [[REG2:r[0-9]+]], 13
 ; CHECK: sts long.array+1, [[REG2]]
 ; CHECK: sts long.array, [[REG1]]
-; CHECK: ldi [[REG1:r[0-9]+]], 170
-; CHECK: ldi [[REG2:r[0-9]+]], 153
-; CHECK: sts long.array+11, [[REG2]]
-; CHECK: sts long.array+10, [[REG1]]
-; CHECK: ldi [[REG1:r[0-9]+]], 204
-; CHECK: ldi [[REG2:r[0-9]+]], 187
-; CHECK: sts long.array+9, [[REG2]]
-; CHECK: sts long.array+8, [[REG1]]
   store i32 2887454020, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @long.array, i32 0, i64 0)
   store i32 1432778632, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @long.array, i32 0, i64 1)
   store i32 2578103244, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @long.array, i32 0, i64 2)


### PR DESCRIPTION
The way the LDWRdPtr pseudo instruction has been modified (since 87c4dc90ec), requires use of the Y or Z registers because it now includes an LDD instruction in the expanded version, those are only valid on Y or Z.
    
    This is a small hack intended to ensure that only Y or Z can be used. Not sure if it's good but it should fix the crashes while maintaining the benefit of the original bugfix.